### PR TITLE
Set default TFM for Traversal to SDK version

### DIFF
--- a/src/Traversal.UnitTests/TraversalTests.cs
+++ b/src/Traversal.UnitTests/TraversalTests.cs
@@ -204,8 +204,15 @@ namespace Microsoft.Build.Traversal.UnitTests
         [InlineData("RestoreProjectStyle", null, "PackageReference")]
         [InlineData("StopOnFirstFailure", "false", "false")]
         [InlineData("StopOnFirstFailure", null, "true")]
+#if NETFRAMEWORK || NET9_0 // These map how MSBuild.ProjectCreation chooses SDK versions given the TFM of the test
         [InlineData("TargetFramework", "net6.0", "net6.0")]
-        [InlineData("TargetFramework", null, "net45")]
+        [InlineData("TargetFramework", null, "net9.0")]
+#elif NET8_0
+        [InlineData("TargetFramework", "net6.0", "net6.0")]
+        [InlineData("TargetFramework", null, "net8.0")]
+#else
+#error "Update test data for the given target framework"
+#endif
         [InlineData("TraversalProjectNames", "custom.proj", "custom.proj")]
         [InlineData("TraversalProjectNames", null, "dirs.proj")]
         [InlineData("UsingMicrosoftTraversalSdk", null, "true")]

--- a/src/Traversal/Sdk/Traversal.targets
+++ b/src/Traversal/Sdk/Traversal.targets
@@ -26,9 +26,10 @@
     <EnableDefaultItems>false</EnableDefaultItems>
 
     <!--
-      TargetFramework is required for restore and used to default to .NET Framework v4.5.  However, Traversal projects don't specify a version so it needs to be defaulted here.
+      TargetFramework is required for restore. If the user specifies a version, use that. Otherwise, use the
+      NETCoreAppMaximumVersion so that the project acts as if it were part of the SDK.
     -->
-    <TargetFramework Condition="'$(TargetFramework)' == ''">net45</TargetFramework>
+    <TargetFramework Condition=" '$(TargetFramework)' == '' ">net$(NETCoreAppMaximumVersion)</TargetFramework>
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />


### PR DESCRIPTION
Fixes #602.

Defaulting to `net45` feels odd, as it means folks are taking _new_ dependencies on .NET Framework without realizing it. It can also lead to oddities like #602 where old defaults apply to newer projects.

This change allows the user to specify a particular version as before. However, if `$(NETCoreSdkVersion)` is set that becomes the default version. If for some reason that isn't set, we fall back to the old version.

I think this strikes a better balance, where users that care or need a specific version continue to do so, while those that consider Traversal projects more a facility of the build system get a more modern default.